### PR TITLE
Refactor form payload handling, clean unused imports, and update redux-persist config

### DIFF
--- a/src/components/EditForm.tsx
+++ b/src/components/EditForm.tsx
@@ -19,7 +19,6 @@ export default function EditForm(props: Props) {
 
   const { id, date, time, instructor } = current!;
 
-  const [add, setAdd] = useState({});
   const [originDate, setOriginDate] = useState<string | undefined>();
   const [currentDate, setCurrentDate] = useState<string | undefined>();
   const [currentTime, setCurrentTime] = useState<number | string | undefined>();
@@ -40,15 +39,6 @@ export default function EditForm(props: Props) {
     setCurrentTime(time);
     setCurrentInstructor(instructor);
   }, []);
-
-  useEffect(() => {
-    setAdd({
-      id,
-      date: currentDate,
-      time: currentTime,
-      instructor: currentInstructor,
-    });
-  }, [currentDate, currentTime, currentInstructor]);
 
   const onSetDate = (props: Date | null | undefined) => {
     const pickerDate = props;
@@ -78,14 +68,14 @@ export default function EditForm(props: Props) {
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    setAdd({
+    const payload = {
       id,
       date: currentDate,
       time: currentTime,
       instructor: currentInstructor,
-    });
+    };
 
-    dispatch(edit(add));
+    dispatch(edit(payload));
 
     if (firstSelect.current || secondSelect.current) {
       firstSelect.current.clearValue();

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FormEvent, useEffect, useRef, useState } from "react";
+import { FormEvent, useRef, useState } from "react";
 import { useAppDispatch } from "@/store/store";
 import PickerDate from "@/components/PickerDate";
 import { insert } from "./../store/bookingSlice";
@@ -11,9 +11,6 @@ import SubmitBtn from "./SubmitBtn";
 import { useTranslation } from "react-i18next";
 
 export function Form() {
-  const [add, setAdd] = useState({});
-
-  const [id, setId] = useState("");
   const [date, setDate] = useState<string | undefined>();
 
   const [selectedTime, setselectedTime] = useState<number | string | undefined>(
@@ -29,15 +26,6 @@ export function Form() {
   const dispatch = useAppDispatch();
 
   const { t } = useTranslation();
-
-  useEffect(() => {
-    setAdd({
-      id: uuid(),
-      date: date,
-      time: selectedTime,
-      instructor: selectedInstructor,
-    });
-  }, [id, date, selectedTime, selectedInstructor]);
 
   //PickerDate
   const onSetDate = (props: Date | null | undefined) => {
@@ -67,14 +55,12 @@ export function Form() {
   function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    setId(uuid());
-
-    setAdd({
-      id: id,
+    const payload = {
+      id: uuid(),
       date: date,
       time: selectedTime,
       instructor: selectedInstructor,
-    });
+    };
 
     if (selectedTime === undefined) {
       toast.error(`${t("toast-text3")}`, { duration: 2000 });
@@ -85,7 +71,7 @@ export function Form() {
       return;
     }
 
-    dispatch(insert(add));
+    dispatch(insert(payload));
     toast.success(`${t("toast-text5")}`, { duration: 2000 });
 
     if (firstSelect.current || secondSelect.current) {

--- a/src/components/Tbody.tsx
+++ b/src/components/Tbody.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import { collection, getDocs } from "firebase/firestore";
-import { useEffect, useState } from "react";
-import fireStore from "../firebase/firestore";
-import { useAppSelector } from "../store/store";
 import DeleteBtn from "./DeleteBtn";
-import Link from "next/link";
-import EditIcon from "./icons/EditIcon";
 
 import Info from "@/components/Info";
 import { InfoType } from "@/app/types/type";

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -2,12 +2,11 @@ import { configureStore } from "@reduxjs/toolkit";
 import { useDispatch, useSelector, useStore } from "react-redux";
 import { bookingReducer } from "./bookingSlice";
 import storage from "redux-persist/lib/storage";
-import { persistReducer } from "redux-persist";
+import { FLUSH, PAUSE, PERSIST, persistReducer, PURGE, REGISTER, REHYDRATE } from "redux-persist";
 
 const persistConfig = {
-  key: "todos",
+  key: "booking",
   storage,
-  whitelist: ["todos"],
 };
 
 const persistedReducer = persistReducer(persistConfig, bookingReducer);
@@ -17,7 +16,11 @@ export const store = configureStore({
     booking: persistedReducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({ serializableCheck: false }),
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
 });
 
 type AppStore = typeof store;


### PR DESCRIPTION
### Motivation
- Simplify form submission logic by constructing payload objects at submit time instead of maintaining intermediary `add` state and related effects to avoid stale state and make the intent clearer.
- Remove unused imports and commented-out DB loading code to reduce clutter.
- Prevent redux-persist serializable-check warnings and align persist key with the store slice by ignoring persistence lifecycle actions in middleware and updating the persist key to `booking`.

### Description
- Replace local `add` state and associated `useEffect` logic in `Form.tsx` and `EditForm.tsx` with a local `payload` object created inside `onSubmit`, and dispatch `insert(payload)` / `edit(payload)` respectively.
- Remove unused state and imports from `Form.tsx` and `Tbody.tsx` (cleanup of `useEffect`, `useState`, Firestore helpers, `Link`, and `EditIcon`).
- Update `src/store/store.tsx` to change `persistConfig.key` from `todos` to `booking`, import redux-persist lifecycle action constants, and configure `getDefaultMiddleware` to ignore `[FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER]` in `serializableCheck`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe631ae40832b8c80a560a82c63f8)