### PR TITLE
Refactor form handling and radio filters; streamline state and update Redux Persist config

### DIFF
--- a/src/components/EditForm.tsx
+++ b/src/components/EditForm.tsx
@@ -19,7 +19,6 @@ export default function EditForm(props: Props) {
 
   const { id, date, time, instructor } = current!;
 
-  const [add, setAdd] = useState({});
   const [originDate, setOriginDate] = useState<string | undefined>();
   const [currentDate, setCurrentDate] = useState<string | undefined>();
   const [currentTime, setCurrentTime] = useState<number | string | undefined>();
@@ -40,15 +39,6 @@ export default function EditForm(props: Props) {
     setCurrentTime(time);
     setCurrentInstructor(instructor);
   }, []);
-
-  useEffect(() => {
-    setAdd({
-      id,
-      date: currentDate,
-      time: currentTime,
-      instructor: currentInstructor,
-    });
-  }, [currentDate, currentTime, currentInstructor]);
 
   const onSetDate = (props: Date | null | undefined) => {
     const pickerDate = props;
@@ -78,14 +68,14 @@ export default function EditForm(props: Props) {
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    setAdd({
+    const payload = {
       id,
       date: currentDate,
       time: currentTime,
       instructor: currentInstructor,
-    });
+    };
 
-    dispatch(edit(add));
+    dispatch(edit(payload));
 
     if (firstSelect.current || secondSelect.current) {
       firstSelect.current.clearValue();

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { FormEvent, useEffect, useRef, useState } from "react";
+import { FormEvent, useRef, useState } from "react";
 import { useAppDispatch } from "@/store/store";
 import PickerDate from "@/components/PickerDate";
 import { insert } from "./../store/bookingSlice";
@@ -11,9 +11,6 @@ import SubmitBtn from "./SubmitBtn";
 import { useTranslation } from "react-i18next";
 
 export function Form() {
-  const [add, setAdd] = useState({});
-
-  const [id, setId] = useState("");
   const [date, setDate] = useState<string | undefined>();
 
   const [selectedTime, setselectedTime] = useState<number | string | undefined>(
@@ -29,15 +26,6 @@ export function Form() {
   const dispatch = useAppDispatch();
 
   const { t } = useTranslation();
-
-  useEffect(() => {
-    setAdd({
-      id: uuid(),
-      date: date,
-      time: selectedTime,
-      instructor: selectedInstructor,
-    });
-  }, [id, date, selectedTime, selectedInstructor]);
 
   //PickerDate
   const onSetDate = (props: Date | null | undefined) => {
@@ -67,14 +55,12 @@ export function Form() {
   function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    setId(uuid());
-
-    setAdd({
-      id: id,
+    const payload = {
+      id: uuid(),
       date: date,
       time: selectedTime,
       instructor: selectedInstructor,
-    });
+    };
 
     if (selectedTime === undefined) {
       toast.error(`${t("toast-text3")}`, { duration: 2000 });
@@ -85,7 +71,7 @@ export function Form() {
       return;
     }
 
-    dispatch(insert(add));
+    dispatch(insert(payload));
     toast.success(`${t("toast-text5")}`, { duration: 2000 });
 
     if (firstSelect.current || secondSelect.current) {

--- a/src/components/Radio.tsx
+++ b/src/components/Radio.tsx
@@ -2,37 +2,31 @@
 
 import RadioBtn from "@/components/RadioBtn";
 import RadioGroup from "@/components/RadioGroup";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { useMemo } from "react";
 
 type Props = {
   type: "time" | "instructor";
-  handleData: Dispatch<SetStateAction<{}>>;
+  value: string;
+  onChange: (value: string) => void;
 };
 
-export default function Radio(props: Props) {
-  const { type, handleData } = props;
-  const [time, setTime] = useState("All");
-  const [instructor, setInstructor] = useState("All");
+export default function Radio({ type, value, onChange }: Props) {
+  const data = useMemo(
+    () =>
+      type === "time"
+        ? ["All", "9", "12", "3", "6"]
+        : ["All", "홍길동", "고영희", "김철수"],
+    [type]
+  );
 
-  const timeArray = ["All", "9", "12", "3", "6"];
-  const instructorArray = ["All", "홍길동", "고영희", "김철수"];
-
-  let data = type === "time" ? timeArray : instructorArray;
-
-  useEffect(() => {
-    type === "time" ? handleData(time) : handleData(instructor);
-  }, [time, instructor]);
+  const label = type === "time" ? "연수시간" : "연수강사";
 
   return (
     <div>
-      <RadioGroup
-        label={type === "time" ? "연수시간" : "연수강사"}
-        value={type === "time" ? time : instructor}
-        onChange={type === "time" ? setTime : setInstructor}
-      >
-        {data.map((data, index) => (
-          <RadioBtn key={index} value={data}>
-            {data}
+      <RadioGroup label={label} value={value} onChange={onChange}>
+        {data.map((item) => (
+          <RadioBtn key={item} value={item}>
+            {item}
           </RadioBtn>
         ))}
       </RadioGroup>

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { RadioContext } from "@/context/RadioContext";
-import { Dispatch, ReactNode, SetStateAction } from "react";
+import { ReactNode } from "react";
 
 type Rest = {
   value: string;
-  onChange: Dispatch<SetStateAction<string>>;
+  onChange: (value: string) => void;
 };
 
 //type alias

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -3,50 +3,34 @@ import Thead from "./Thead";
 import Tbody from "./Tbody";
 import Radio from "@/components/Radio";
 import { useAppSelector } from "@/store/store";
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 import { InfoType } from "@/app/types/type";
 
 export default function Table() {
   const booking: InfoType[] = useAppSelector((state) => state.booking.todos);
-  const [filterdata, setFilterData] = useState<InfoType[]>(booking);
-  const [target, setTarget] = useState<number | string | undefined>();
-  const [selectedInstructor, setSelectedInstructor] = useState<
-    string | undefined
-  >();
+  const [selectedTime, setSelectedTime] = useState("All");
+  const [selectedInstructor, setSelectedInstructor] = useState("All");
 
-  const handleFilterTime = (props: any) => {
-    let value;
-    props != "All" ? (value = Number(props)) : (value = "All");
-    setTarget(value);
-  };
+  const filteredData = useMemo(() => {
+    const byTime =
+      selectedTime === "All"
+        ? booking
+        : booking.filter((data) => data.time === Number(selectedTime));
 
-  const handleFilterInstructor = (props: any) => {
-    const value = props;
-    setSelectedInstructor(value);
-  };
-
-  useEffect(() => {
-    let temp: InfoType[] = [];
-    if (target !== "All") {
-      temp = booking.filter((data) => {
-        return data.time === target;
-      });
-    } else {
-      temp = booking;
-    }
-    if (selectedInstructor !== "All") {
-      let temp2 = temp.filter((data) => data.instructor === selectedInstructor);
-      setFilterData(temp2);
-    } else {
-      setFilterData(temp);
-    }
-  }, [booking, target, selectedInstructor]);
+    return selectedInstructor === "All"
+      ? byTime
+      : byTime.filter((data) => data.instructor === selectedInstructor);
+  }, [booking, selectedInstructor, selectedTime]);
 
   return (
     <div className="lg:flex lg:items-start">
       <div className="mb-[15px] lg:mb-0 lg:mr-[10px] border border-indigo-500/15">
-        <Radio type="time" handleData={handleFilterTime} />
-        <Radio type="instructor" handleData={handleFilterInstructor} />
+        <Radio type="time" value={selectedTime} onChange={setSelectedTime} />
+        <Radio
+          type="instructor"
+          value={selectedInstructor}
+          onChange={setSelectedInstructor}
+        />
       </div>
       <table className="w-full text-center border border-indigo-500/15 ">
         <caption className="hidden">driving lesson list table</caption>
@@ -59,7 +43,7 @@ export default function Table() {
           <col width="10%" />
         </colgroup>
         <Thead />
-        <Tbody bookingdata={filterdata} />
+        <Tbody bookingdata={filteredData} />
       </table>
     </div>
   );

--- a/src/components/Tbody.tsx
+++ b/src/components/Tbody.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import { collection, getDocs } from "firebase/firestore";
-import { useEffect, useState } from "react";
-import fireStore from "../firebase/firestore";
-import { useAppSelector } from "../store/store";
 import DeleteBtn from "./DeleteBtn";
-import Link from "next/link";
-import EditIcon from "./icons/EditIcon";
 
 import Info from "@/components/Info";
 import { InfoType } from "@/app/types/type";

--- a/src/context/RadioContext.tsx
+++ b/src/context/RadioContext.tsx
@@ -1,9 +1,8 @@
 import { createContext } from "react";
-import { Dispatch, SetStateAction } from "react";
 
 type contextType = {
   value: string;
-  onChange: Dispatch<SetStateAction<string>>;
+  onChange: (value: string) => void;
 };
 
 export const RadioContext = createContext<contextType>({} as contextType);

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -2,12 +2,11 @@ import { configureStore } from "@reduxjs/toolkit";
 import { useDispatch, useSelector, useStore } from "react-redux";
 import { bookingReducer } from "./bookingSlice";
 import storage from "redux-persist/lib/storage";
-import { persistReducer } from "redux-persist";
+import { FLUSH, PAUSE, PERSIST, persistReducer, PURGE, REGISTER, REHYDRATE } from "redux-persist";
 
 const persistConfig = {
-  key: "todos",
+  key: "booking",
   storage,
-  whitelist: ["todos"],
 };
 
 const persistedReducer = persistReducer(persistConfig, bookingReducer);
@@ -17,7 +16,11 @@ export const store = configureStore({
     booking: persistedReducer,
   },
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({ serializableCheck: false }),
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
 });
 
 type AppStore = typeof store;


### PR DESCRIPTION
### Motivation
- Remove redundant intermediate state objects and simplify form submit payload construction to reduce stale state bugs and improve readability.
- Convert radio filter components to be controlled from the parent to centralize filtering state and avoid duplicated internal state.
- Fix Redux Persist serializableMiddleware warnings and ensure persistence key/name is consistent.

### Description
- Removed `add` state and related `useEffect` in `EditForm.tsx` and `Form.tsx`, and construct a `payload` object inline in `onSubmit` before dispatching `edit`/`insert` respectively.
- Converted `Radio` to a controlled component that accepts `value` and `onChange`, removed internal state and `useEffect`, and memoized options with `useMemo` in `Radio.tsx`.
- Updated `RadioGroup` and `RadioContext` types to use a simple `(value: string) => void` `onChange` signature.
- Replaced the previous `useEffect`-based filtering in `Table.tsx` with a `useMemo`-based `filteredData` derived from `selectedTime` and `selectedInstructor`, and wired the new controlled `Radio` props through the component tree.
- Cleaned up unused imports and dead code in `Tbody.tsx` by removing commented database loading and unused firebase imports.
- Adjusted `store.tsx` Redux persist configuration: changed `key` from `todos` to `booking`, added `ignoredActions` (`FLUSH`, `REHYDRATE`, `PAUSE`, `PERSIST`, `PURGE`, `REGISTER`) to the middleware `serializableCheck` to prevent warnings.

### Testing
- Ran a local build with `npm run build` which completed successfully.
- Ran lint checks with `npm run lint` which reported no new errors.
- No failing automated tests were observed in the local environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe631ae40832b8c80a560a82c63f8)