### PR TITLE
Add async booking insert with status handling and disable submit during save

### DIFF
--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { FormEvent, useReducer, useRef } from "react";
-import { useAppDispatch } from "@/store/store";
+import { useAppDispatch, useAppSelector } from "@/store/store";
 import PickerDate from "@/components/PickerDate";
-import { insert } from "./../store/bookingSlice";
+import { insertAsync } from "./../store/bookingSlice";
 import toast from "react-hot-toast";
 import React from "react";
 import uuid from "react-uuid";
@@ -50,6 +50,7 @@ export function Form() {
   const secondSelect = useRef<any>(null);
 
   const dispatch = useAppDispatch();
+  const bookingStatus = useAppSelector((state) => state.booking.status);
 
   const { t } = useTranslation();
 
@@ -76,7 +77,7 @@ export function Form() {
       : formDispatch({ type: "setInstructor", payload: selectedValue });
   };
 
-  function onSubmit(event: FormEvent<HTMLFormElement>) {
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     const payload = {
@@ -95,8 +96,15 @@ export function Form() {
       return;
     }
 
-    dispatch(insert(payload));
-    toast.success(`${t("toast-text5")}`, { duration: 2000 });
+    try {
+      const insertAsyncAction = insertAsync as unknown as (bookingPayload: typeof payload) => any;
+      await dispatch(insertAsyncAction(payload)).unwrap();
+      toast.success(`${t("toast-text5")}`, { duration: 2000 });
+    } catch (error) {
+      const errorMessage = typeof error === "string" ? error : "예약 저장에 실패했습니다.";
+      toast.error(errorMessage, { duration: 2000 });
+      return;
+    }
 
     if (firstSelect.current || secondSelect.current) {
       firstSelect.current.clearValue();
@@ -137,7 +145,7 @@ export function Form() {
           handleTime={handleSelectedValue}
         />
       </label>
-      <SubmitBtn type="save" />
+      <SubmitBtn type="save" disabled={bookingStatus === "loading"} />
     </form>
   );
 }

--- a/src/components/SubmitBtn.tsx
+++ b/src/components/SubmitBtn.tsx
@@ -6,17 +6,19 @@ import SubmitIcon from "./icons/SubmitIcon";
 
 type Props = {
   type: "save" | "fix";
+  disabled?: boolean;
 };
 
 export default function SubmitBtn(props: Props) {
   const { t } = useTranslation();
-  const { type } = props;
+  const { type, disabled = false } = props;
 
   return (
     <div className="flex justify-center mt-5">
       <button
         type="submit"
-        className="flex items-center p-3 rounded common-hover-style"
+        disabled={disabled}
+        className="flex items-center p-3 rounded common-hover-style disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <SubmitIcon />
         <span className="ml-1">

--- a/src/store/bookingSlice.js
+++ b/src/store/bookingSlice.js
@@ -1,8 +1,34 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
   todos: [],
+  status: "idle",
+  error: null,
 };
+
+const mockInsertBookingApi = async (payload) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (!payload.date || !payload.time || !payload.instructor) {
+        reject(new Error("필수 예약 정보가 누락되었습니다."));
+        return;
+      }
+
+      resolve(payload);
+    }, 500);
+  });
+
+export const insertAsync = createAsyncThunk(
+  "booking/insertAsync",
+  async (payload, { rejectWithValue }) => {
+    try {
+      const response = await mockInsertBookingApi(payload);
+      return response;
+    } catch (error) {
+      return rejectWithValue(error.message);
+    }
+  }
+);
 
 export const bookingSlice = createSlice({
   name: "booking",
@@ -29,6 +55,21 @@ export const bookingSlice = createSlice({
           : todo
       ),
     }),
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(insertAsync.pending, (state) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(insertAsync.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.todos = state.todos.concat(action.payload);
+      })
+      .addCase(insertAsync.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload ?? "예약 저장 중 오류가 발생했습니다.";
+      });
   },
 });
 


### PR DESCRIPTION
### Motivation
- Introduce asynchronous booking persistence with proper error handling and UI feedback when saving a booking. 
- Prevent duplicate submissions by disabling the save button while an insert is in progress.

### Description
- Add `insertAsync` as a `createAsyncThunk` and a `mockInsertBookingApi` to simulate async booking persistence, and extend the booking slice state with `status` and `error` plus `extraReducers` for `pending`/`fulfilled`/`rejected` handling. 
- Update `Form` to select `booking.status` via `useAppSelector`, make `onSubmit` async and dispatch the `insertAsync` thunk with `await`/`unwrap()` and show success or error toasts accordingly, while clearing selections only after success. 
- Extend `SubmitBtn` to accept a `disabled` prop and apply `disabled` attributes and styles so the button is visually and functionally disabled when `booking.status === "loading"`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbdce2caf4832b9ad46567f19c6caf)